### PR TITLE
A method for dumping of current IMG to FITS/npy

### DIFF
--- a/Pipeline.py
+++ b/Pipeline.py
@@ -11,6 +11,7 @@ from autoprofutils.Mask import Star_Mask_IRAF, Mask_Segmentation_Map, Bad_Pixel_
 from autoprofutils.Isophote_Extract import Isophote_Extract, Isophote_Extract_Forced
 from autoprofutils.Check_Fit import Check_Fit
 from autoprofutils.Write_Prof import WriteProf
+from autoprofutils.Write_Fi import WriteFi
 from autoprofutils.Ellipse_Model import EllipseModel_Fix, EllipseModel_General
 from autoprofutils.Radial_Profiles import Radial_Profiles
 from autoprofutils.Axial_Profiles import Axial_Profiles
@@ -55,6 +56,7 @@ class Isophote_Pipeline(object):
                                  'isophoteinit': Isophote_Initialize,
                                  'isophoteinit mean': Isophote_Initialize_mean,
                                  'plot image': Plot_Galaxy_Image,
+                                 'writefi': WriteFi,
                                  'isophotefit': Isophote_Fit_FFT_Robust,
                                  'isophotefit mean': Isophote_Fit_FFT_mean,
                                  'isophotefit forced': Isophote_Fit_Forced,

--- a/autoprofutils/Write_Fi.py
+++ b/autoprofutils/Write_Fi.py
@@ -22,20 +22,20 @@ def WriteFi(IMG, results, options):
         else:
             return fi
     
+    # Write npy file
+    if writeas == 'npy':
+        fi = saveto + options['ap_name'] + '_AP.000.npy'
+        fi = _iterate_filename(fi)
+        with open(fi, 'wb') as f:
+            np.save(f, IMG)
+
     # Write fits file
-    if writeas == 'fits':
+    else:
         fi = saveto + options['ap_name'] + '_AP.000.fits'
         fi = _iterate_filename(fi)
         hdu = fits.PrimaryHDU(IMG)
         hdulist = fits.HDUList([hdu])
         hdulist.writeto(fi)
         hdulist.close()
-
-    # Write npy file
-    else:
-        fi = saveto + options['ap_name'] + '_AP.000.npy'
-        fi = _iterate_filename(fi)
-        with open(fi, 'wb') as f:
-            np.save(fi, IMG)
 
     return IMG, {}

--- a/autoprofutils/Write_Fi.py
+++ b/autoprofutils/Write_Fi.py
@@ -1,0 +1,41 @@
+from astropy.io import fits
+import numpy as np
+import sys
+import os
+sys.path.append(os.environ['AUTOPROF'])
+
+def WriteFi(IMG, results, options):
+    """
+    Writes the galaxy image to disk.
+    """
+    
+    saveto = options['ap_saveto'] if 'ap_saveto' in options else './'
+    writeas = options['ap_writeas'] if 'ap_writeas' in options else 'fits' 
+
+    def _iterate_filename(fi):
+        """ If file exists add one to the end of the existing file to avoid clobbering. """
+        dir_, base = os.path.split(fi)
+        if os.path.exists(fi):
+            sep_base = base.split(os.path.extsep)
+            base = sep_base[0] + '.{:03d}'.format(int(sep_base[1]) + 1) + '.' + sep_base[2]
+            return _iterate_filename(os.path.join(dir_, base))
+        else:
+            return fi
+    
+    # Write fits file
+    if writeas == 'fits':
+        fi = saveto + options['ap_name'] + '_AP.000.fits'
+        fi = _iterate_filename(fi)
+        hdu = fits.PrimaryHDU(IMG)
+        hdulist = fits.HDUList([hdu])
+        hdulist.writeto(fi)
+        hdulist.close()
+
+    # Write npy file
+    else:
+        fi = saveto + options['ap_name'] + '_AP.000.npy'
+        fi = _iterate_filename(fi)
+        with open(fi, 'wb') as f:
+            np.save(fi, IMG)
+
+    return IMG, {}


### PR DESCRIPTION
	modified:   ../../Pipeline.py
	new file:   ../../autoprofutils/Write_Fi.py

This ``Write_FI`` method writes the IMG as it is at the point where
writefi is inserted into the pipeline. Currently I have implemented both
fits and npy binary dumps.

If the dumped file will be clobbered then the filename is iterated upon
(i.e. *.000.fits becomes *.001.fits).