### PR TITLE
Added min max norm and percentile clip

### DIFF
--- a/Pipeline.py
+++ b/Pipeline.py
@@ -5,7 +5,7 @@ from autoprofutils.Plotting_Steps import Plot_Galaxy_Image
 from autoprofutils.Background import Background_Mode, Background_DilatedSources, Background_Unsharp, Background_Basic
 from autoprofutils.PSF import PSF_IRAF, PSF_StarFind
 from autoprofutils.Center import Center_2DGaussian, Center_1DGaussian, Center_OfMass, Center_HillClimb, Center_Forced, Center_HillClimb_mean
-from autoprofutils.ImageTransform import Crop
+from autoprofutils.ImageTransform import Crop, MinMaxNorm, PercentileClip
 from autoprofutils.Isophote_Initialize import Isophote_Initialize, Isophote_Initialize_mean
 from autoprofutils.Isophote_Fit import Isophote_Fit_FFT_Robust, Isophote_Fit_Forced, Photutils_Fit, Isophote_Fit_FFT_mean
 from autoprofutils.Mask import Star_Mask_IRAF, Mask_Segmentation_Map, Bad_Pixel_Mask
@@ -55,6 +55,8 @@ class Isophote_Pipeline(object):
                                  'center 1DGaussian': Center_1DGaussian,
                                  'center OfMass': Center_OfMass,
                                  'crop': Crop,
+                                 'minmaxnorm': MinMaxNorm,
+                                 'percentile clip': PercentileClip,
                                  'isophoteinit': Isophote_Initialize,
                                  'isophoteinit mean': Isophote_Initialize_mean,
                                  'plot image': Plot_Galaxy_Image,

--- a/autoprofutils/ImageTransform.py
+++ b/autoprofutils/ImageTransform.py
@@ -27,3 +27,25 @@ def Crop(IMG, results, options):
               center[1] - cropto[1]//2:center[1] + cropto[1]//2]
 
     return IMG, {}
+
+def MinMaxNorm(IMG, results, options):
+    """
+    Perform a min max norm on the image, normalising all pixels to values
+    within the closed interval [0, 1].
+    """
+    IMG = (IMG - np.min(IMG))/(np.max(IMG) - np.min(IMG))
+
+    return IMG, {}
+
+def PercentileClip(IMG, results, options):
+    """
+    Perform an upper bound percentile clip on the image.
+
+    ap_percentileclip states the percentile to clip pixels at.
+    We default to 99.9%.
+    """
+    percentile = options['ap_percentileclip'] if 'ap_percentileclip' in options else 99.9
+    p = np.percentile(IMG, percentile)
+    IMG = np.where(IMG <= p, IMG, p)
+
+    return IMG, {'clipped at': p}


### PR DESCRIPTION
	modified:   Pipeline.py
	modified:   autoprofutils/ImageTransform.py

I have added min max normalisation and percentile clip routines to
ImageTransform.py.

The new option 'ap_percentileclip' defines where to clip an incoming
image's pixel values at.