### PR TITLE
fix clustering of global ellipticities

### DIFF
--- a/autoprof/pipeline_steps/Isophote_Initialize.py
+++ b/autoprof/pipeline_steps/Isophote_Initialize.py
@@ -260,6 +260,27 @@ def Isophote_Initialize(IMG, results, options):
                 )
             )
         )
+    # Find global ellipticity: second pass
+    ellip = test_ellip[np.argmin(test_f2)]
+    test_ellip = np.linspace(ellip - 0.05, ellip + 0.05, 15)
+    test_f2 = []
+    for e in test_ellip:
+        test_f2.append(
+            sum(
+                list(
+                    _fitEllip_loss(
+                        e,
+                        dat,
+                        circ_ellipse_radii[-2] * m,
+                        phase,
+                        results["center"],
+                        results["background noise"],
+                        mask,
+                    )
+                    for m in np.linspace(0.8, 1.2, 5)
+                )
+            )
+        )
     ellip = test_ellip[np.argmin(test_f2)]
     res = minimize(
         lambda e, d, r, p, c, n, msk: sum(
@@ -463,6 +484,26 @@ def Isophote_Initialize_mean(IMG, results, options):
 
     # Find global ellipticity
     test_ellip = np.linspace(0.05, 0.95, 15)
+    test_f2 = []
+    for e in test_ellip:
+        test_f2.append(
+            sum(
+                list(
+                    _fitEllip_mean_loss(
+                        e,
+                        dat,
+                        circ_ellipse_radii[-2] * m,
+                        phase,
+                        results["center"],
+                        results["background noise"],
+                    )
+                    for m in np.linspace(0.8, 1.2, 5)
+                )
+            )
+        )
+    # Find global ellipticity: second pass
+    ellip = test_ellip[np.argmin(test_f2)]
+    test_ellip = np.linspace(ellip - 0.05, ellip + 0.05, 15)
     test_f2 = []
     for e in test_ellip:
         test_f2.append(


### PR DESCRIPTION
The current implementation causes a clustering of the global ellipticities around the grid values, particularly for galaxies that are close to face-on. In order to increase the resolution of the grids and mitigate this issue, we have introduced a second pass to search for the optimal grid ellipticity. This approach results in a ~10 times increase in grid resolution, with only a ~10% increase in computing time during the initialization stage. Our tests on ~8000 galaxy images show that this second pass effectively removes the clustering, as can be seen in the attached plots.

![image](https://user-images.githubusercontent.com/8177868/224295815-83478a38-8409-4a97-b9b4-cc1dcf92c306.png)
![image](https://user-images.githubusercontent.com/8177868/224295869-20364c92-345c-4b40-ab8a-19b1eaed5065.png)
