### PR TITLE
Update old dependency caps

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
       - uses: actions/checkout@master
@@ -35,7 +35,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install pytest
           pip install wheel
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         shell: bash
       - name: Install AutoProf
         run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-astropy>=3.2.3,<6.0
+astropy>=3.2.3
 matplotlib>=3.1.2
-numpy>=1.17.4,<2.0
-photutils>=0.7.2,<=1.5.0
+numpy>=1.17.4
+photutils>=1.5.0
 scikit-learn>=0.21.3
 scipy>=1.3.3

--- a/requirements_build.txt
+++ b/requirements_build.txt
@@ -1,7 +1,7 @@
-astropy>=3.2.3,<6.0
+astropy>=3.2.3
 matplotlib>=3.1.2
-numpy>=1.17.4,<2.0
-photutils>=0.7.2,<=1.5.0
+numpy>=1.17.4
+photutils>=1.5.0
 scikit-learn>=0.21.3
 scipy>=1.3.3
 sphinx_rtd_theme

--- a/src/autoprof/pipeline_steps/Background.py
+++ b/src/autoprof/pipeline_steps/Background.py
@@ -1,4 +1,10 @@
-from photutils.segmentation import SegmentationImage
+from astropy.convolution import convolve
+from astropy.stats import SigmaClip
+from photutils.segmentation import (
+    detect_sources,
+    detect_threshold,
+    make_2dgaussian_kernel,
+)
 from scipy.stats import iqr
 from scipy.fftpack import fft2, ifft2
 import logging
@@ -162,14 +168,30 @@ def Background_DilatedSources(IMG, results, options):
     # such as stars and galaxies, including a boarder
     # around each source.
     if not ("ap_set_background" in options and "ap_set_background_noise" in options):
-        segm = SegmentationImage(IMG)
-        source_mask = segm.make_source_mask(
-            nsigma=3,
-            npixels=int(1.0 / options["ap_pixscale"]),
-            dilate_size=40,
-            filter_fwhm=1.0 / options["ap_pixscale"],
-            filter_size=int(3.0 / options["ap_pixscale"]),
-            sigclip_iters=5,
+        threshold = detect_threshold(
+            IMG,
+            3,
+            sigma_clip=SigmaClip(sigma=3, maxiters=5),
+        )
+        filter_size = int(3.0 / options["ap_pixscale"])
+        # Photutils requires an odd kernel size around the central pixel.
+        if filter_size % 2 == 0:
+            filter_size += 1
+        kernel = make_2dgaussian_kernel(
+            1.0 / options["ap_pixscale"],
+            filter_size,
+        )
+        convolved_IMG = convolve(IMG, kernel)
+        segm = detect_sources(
+            convolved_IMG,
+            threshold,
+            int(1.0 / options["ap_pixscale"]),
+        )
+        # Source detection can legitimately return no segmentation map.
+        source_mask = (
+            np.zeros(IMG.shape, dtype=bool)
+            if segm is None
+            else segm.make_source_mask(size=40)
         )
         mask = np.logical_or(mask, source_mask)
 

--- a/src/autoprof/pipeline_steps/Mask.py
+++ b/src/autoprof/pipeline_steps/Mask.py
@@ -1,4 +1,4 @@
-from photutils import DAOStarFinder, IRAFStarFinder
+from photutils.detection import IRAFStarFinder
 import numpy as np
 import matplotlib.pyplot as plt
 from astropy.visualization import SqrtStretch, LogStretch

--- a/src/autoprof/pipeline_steps/PSF.py
+++ b/src/autoprof/pipeline_steps/PSF.py
@@ -1,4 +1,4 @@
-from photutils import DAOStarFinder, IRAFStarFinder
+from photutils.detection import IRAFStarFinder
 import numpy as np
 from scipy.stats import iqr
 import matplotlib.pyplot as plt


### PR DESCRIPTION
Updates AutoProf's old dependency caps so it can be installed in newer Python astronomy environments.

- move the star-finder imports to the supported Photutils subpackage
- replace the removed source-mask convenience API with the current segmentation workflow
- remove the old NumPy and Astropy upper bounds and require Photutils 1.5 or newer
- modify CI matrix to test Python 3.9 through 3.13 on Linux, Windows, and macOS
- let `pip install .` resolve dependencies through AutoProf's package metadata instead of pre-installing `requirements.txt`, so CI tests the real installation path

Locally, the existing five tests pass in an isolated Python 3.13 environment with NumPy 2.5.1, Astropy 8.0.1, and Photutils 3.0.0. The dilated-source path also passes focused checks with Photutils 2.3 and 3.0.

Closes #29
